### PR TITLE
Optimize the download of packages by using dists by default

### DIFF
--- a/src/Mouf/Packanalyst/Command/RunCommand.php
+++ b/src/Mouf/Packanalyst/Command/RunCommand.php
@@ -19,7 +19,7 @@ use Composer\Package\PackageInterface;
 use Mouf\Packanalyst\ClassesDetector;
 
 /**
- * 
+ *
  * @author david
  *
  */
@@ -28,7 +28,7 @@ class RunCommand extends Command
     private $gitConfig;
     private $repos;
     private $downloadManager;
-    
+
     protected function configure()
     {
         $this
@@ -59,17 +59,17 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-    	
+
     	\Mouf::getDownloadLock()->acquireLock();
-    	
+
     	$fetchDataService = \Mouf::getFetchDataService();
     	$fetchDataService->setDownloadManager($this->getDownloadManager());
     	$fetchDataService->setPackagistRepository($this->getPackagistRepository());
-    	
+
     	$package = $input->getOption('package');
     	$retry = $input->getOption('retry');
     	$force = $input->getOption('force');
-    	
+
     	if ($package) {
     		$fetchDataService->setForcedPackage($package);
     	}
@@ -79,12 +79,12 @@ EOT
     	if ($force) {
     		$fetchDataService->setForce(true);
     	}
-    	
+
     	$fetchDataService->run();
     }
 
     /**
-     * 
+     *
      * @return ComposerRepository
      */
     private function getPackagistRepository() {
@@ -93,13 +93,16 @@ EOT
     	}
     	return $this->repos['packagist'];
     }
-    
+
     private function getDownloadManager() {
-    	
+
     	if (!$this->downloadManager) {
 	    	$config = Factory::createConfig();
+            $config->merge(array('config' => array(
+                'preferred-install' => 'dist'
+            )));
 	    	$factory = new Factory;
-	    	 
+
 	    	$this->downloadManager = $factory->createDownloadManager($this->getIO(), $config);
     	}
     	return $this->downloadManager;


### PR DESCRIPTION
Packanalyst is analyzing dev versions of libraries. But the default installation method of Composer for dev version is to use a ``git clone``. This is much longer than downloading a dist and unpacking it.
It is even worse in your case, because you perform a separate clone for each branch instead of updating the same installation to a different version (which would just need to run a very fast ``git checkout`` in composer as commits are already there locally), and so you only get the drawbacks of the source install.
See the blackfire comparison below for this simple change (look at the percentage represented by the time won by this change: 68% of the total time got saved)
https://blackfire.io/profiles/compare/22b855d9-a0a7-474e-895d-bd30c24d11e0/graph

On a side note, this may speed up a bit the filesystem lookup for PHP files (even though it is not visible here as it is far from being the bottleneck), as your current iterator will still look for php files inside the ``.git`` folder instead of excluding the folder early