### PR TITLE
Adding bower files to ignore list following upgrade to koala/composer-extra-assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ config.php
 mouf/no_commit/*
 src/views/node_modules/*
 .idea/*
+.bowerrc
+bower.json


### PR DESCRIPTION
Closes #26

The 2 files are created by koala-framework/composer-extra-assets that calls bower from composer.